### PR TITLE
Use Jetty LifeCycle listener to create lock file for healthcheck

### DIFF
--- a/template/clojure/Dockerfile
+++ b/template/clojure/Dockerfile
@@ -31,4 +31,10 @@ EXPOSE 8080
 
 HEALTHCHECK --interval=2s CMD [ -e /tmp/.lock ] || exit 1
 
+# Do not let the watchdog create the lock file. The watchdog can create the lock
+# file before the Jetty instance is actually ready, causing the function to be
+# exposed too early and causing 500 Internal Server Error responses. Instead,
+# rely on the entrypoint to create the lock file when Jetty is ready.
+ENV suppress_lock=true
+
 CMD ["fwatchdog"]

--- a/template/clojure/entrypoint/src/entrypoint/core.clj
+++ b/template/clojure/entrypoint/src/entrypoint/core.clj
@@ -1,6 +1,30 @@
 (ns entrypoint.core
   (:require [ring.adapter.jetty :refer [run-jetty]]
-            [function.core :refer [app]]))
+            [function.core :refer [app]])
+  (:import [org.eclipse.jetty.util.component LifeCycle$Listener]
+           [java.io File]))
+
+(defn add-lifecycle-listener
+  "Creates a file /tmp/.lock when Jetty is started.
+
+  This is associated with a healthcheck. The existence of the /tmp/.lock file
+  indicates a successful healthcheck and that the container running Jetty is
+  ready to be exposed to traffic."
+  [server]
+  (.addLifeCycleListener server
+                         (reify LifeCycle$Listener
+                           (lifeCycleFailure [_this _event _cause])
+
+                           (lifeCycleStarted [_this _event]
+                             (.createNewFile (java.io.File. "/tmp/.lock")))
+
+                           (lifeCycleStarting [_this _event])
+
+                           (lifeCycleStopped [_this _event])
+
+                           (lifeCycleStopping [_this _event])))
+  server)
 
 (defn -main [& args]
-  (run-jetty app {:port 4000}))
+  (run-jetty app {:port 4000
+                  :configurator add-lifecycle-listener}))


### PR DESCRIPTION
Fixes #1

This commit suppresses of-watchdog from creating a lock file because it
can create the lock file before Jetty is actually ready to receive
traffic, causing the function to be labeled ready before it can
successfully be invoked.

Instead, this commit adds a LifeCycle listener to the Jetty instance
that will create the lock file when the Jetty server has started.