### PR TITLE
Bump 'depstar' to silence "clashing jar item" warn

### DIFF
--- a/template/clojure/entrypoint/deps.edn
+++ b/template/clojure/entrypoint/deps.edn
@@ -1,4 +1,4 @@
 {:deps {function {:local/root "../function"}
         ring/ring-jetty-adapter {:mvn/version "1.7.1"}}
  :paths ["src" "classes"]
- :aliases {:depstar {:extra-deps {seancorfield/depstar {:mvn/version "0.1.5"}}}}}
+ :aliases {:depstar {:extra-deps {seancorfield/depstar {:mvn/version "2.0.171"}}}}}


### PR DESCRIPTION
Similar issue here with similar solution: https://github.com/healthfinch/depstar/issues/4