### PR TITLE
Restore addgroup in Dockerfile (fixes #4)

### DIFF
--- a/template/clojure/Dockerfile
+++ b/template/clojure/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add curl \
 
 FROM openjdk:8u181-jdk-alpine as ship
 
-RUN adduser -S app
+RUN addgroup -S app && adduser -S app -G app
 USER app
 
 ENV upstream_url="http://127.0.0.1:4000"


### PR DESCRIPTION
@ccfontes - would appreciate if you could take a look. This change does set the user group to `app` and chown the fwatchdog and jar file to the group.