### PR TITLE
Pull dependency management into local Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ be run in a jetty server in production.
 
 You may add and use ring middleware and other libraries per usual.
 
+### ARM64 Support
+
+The OpenJDK image used to build the function does not currently support the
+ARM64 architecture. There is an alternative image that may be used to get this
+support.
+
+If you need to enable ARM64 support you should
+[edit the Dockerfile](https://docs.openfaas.com/cli/templates/#update-the-dockerfile)
+and follow the instructions at the top of the file. This will be streamlined in
+a future release when the official OpenJDK images support ARM64.
 
 ### Using compojure
 

--- a/template/clojure/Dockerfile
+++ b/template/clojure/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /home/app/entrypoint
 COPY ./entrypoint/deps.edn ./deps.edn
 COPY ./function/deps.edn ../function/deps.edn
 
-RUN clojure -A:uberjar -Stree
+RUN clojure -A:depstar -Stree
 
 # During the build step, the dev dependencies from the function are fetched. I
 # do not know why. This line will go and fetch those dependencies as an

--- a/template/clojure/Dockerfile
+++ b/template/clojure/Dockerfile
@@ -1,6 +1,24 @@
-FROM tessellator/openfaas-clojure-builder:latest as builder
+FROM openjdk:8u121-jdk-alpine as builder
+
+ENV CLOJURE_VERSION="1.10.3.822"
+
+RUN apk --no-cache add curl bash \
+    && curl -O https://download.clojure.org/install/linux-install-${CLOJURE_VERSION}.sh \
+    && chmod +x linux-install-${CLOJURE_VERSION}.sh \
+    && ./linux-install-${CLOJURE_VERSION}.sh
 
 WORKDIR /home/app/entrypoint
+COPY ./entrypoint/deps.edn ./deps.edn
+COPY ./function/deps.edn ../function/deps.edn
+
+RUN clojure -A:uberjar -Stree
+
+# During the build step, the dev dependencies from the function are fetched. I
+# do not know why. This line will go and fetch those dependencies as an
+# independent step so that if only the function code changes there will be no
+# need to fetch the dev dependencies.
+RUN cd ../function && clojure -A:dev -Stree && cd ../entrypoint
+
 COPY . /home/app
 
 RUN clojure -e "(compile 'entrypoint.core)" \

--- a/template/clojure/Dockerfile
+++ b/template/clojure/Dockerfile
@@ -1,4 +1,10 @@
 FROM openjdk:8u121-jdk-alpine as builder
+# NOTE: If you are targeting ARM64, you will run into an error because the
+# image above does not yet support that architecture. See this issue for more
+# details: https://github.com/tessellator/openfaas-clojure-template/issues/6. 
+# To work around this, comment out the FROM line above and uncomment the one 
+# below.
+#FROM balenalib/generic-aarch64-alpine-openjdk:8-20210225 as builder
 
 ENV CLOJURE_VERSION="1.10.3.822"
 

--- a/template/clojure/Dockerfile
+++ b/template/clojure/Dockerfile
@@ -1,9 +1,11 @@
 FROM openjdk:8u121-jdk-alpine as builder
-# NOTE: If you are targeting ARM64, you will run into an error because the
+# [ARM64]: If you are targeting ARM64, you will run into an error because the
 # image above does not yet support that architecture. See this issue for more
 # details: https://github.com/tessellator/openfaas-clojure-template/issues/6. 
 # To work around this, comment out the FROM line above and uncomment the one 
-# below.
+# below. 
+# You will also need to make changes in the other stages. Each section section 
+# that needs your attention will start with "[ARM64]".
 #FROM balenalib/generic-aarch64-alpine-openjdk:8-20210225 as builder
 
 ENV CLOJURE_VERSION="1.10.3.822"
@@ -39,13 +41,21 @@ WORKDIR /home
 
 ENV WATCHDOG_VERSION="0.8.3"
 
+# [ARM64]: The fwatchdog executable is prebuilt for various architectures. If
+# you are targeting ARM64, you will need to change the ARCH environment variable
+# to pull the correct executable.
+ENV ARCH=amd64
+# ENV ARCH=arm64
+
 RUN apk add curl \
-    && curl -sSL https://github.com/openfaas/of-watchdog/releases/download/${WATCHDOG_VERSION}/fwatchdog-amd64 > fwatchdog \
+    && curl -sSL https://github.com/openfaas/of-watchdog/releases/download/${WATCHDOG_VERSION}/fwatchdog-${ARCH} > fwatchdog \
     && chmod +x ./fwatchdog
 
 ## -----------------------------------------------------------------------------
 
+# [ARM64]: Use the same image as in the builder step.
 FROM openjdk:8u181-jdk-alpine as ship
+# FROM balenalib/generic-aarch64-alpine-openjdk:8-20210225 as ship
 
 RUN addgroup -S app && adduser -S app -G app
 USER app


### PR DESCRIPTION
Pulls in dependency management from an external image into the local Dockerfile. Adds information about how to add ARM64 support.

Fixes #6 